### PR TITLE
Common.README example not using the correct types

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -30,13 +30,13 @@ const sdk = new CodatCommon({
   },
 });
 
-const req: shared.CompanyRequestBody = {
+const req: CompanyRequestBody = {
   description: "corrupti",
   name: "Kelvin Sporer",
 };
 
 sdk.companies.create(req).then((res: CreateCompanyResponse | AxiosError) => {
-  if (res instanceof UsageExamplePostResponse && res.statusCode == 200) {
+  if (res instanceof CreateCompanyResponse && res.statusCode == 200) {
     // handle response
   }
 });


### PR DESCRIPTION
The example usage of the common sdk referenced incorrect types which would get ts compiler errors. The readme has been updated so that the code referenced compiles.