### PR TITLE
Accounting -> Invoices -> downloadPdf (content-type)

### DIFF
--- a/previous-versions/accounting/src/sdk/invoices.ts
+++ b/previous-versions/accounting/src/sdk/invoices.ts
@@ -490,7 +490,7 @@ export class Invoices {
             });
         switch (true) {
             case httpRes?.status == 200:
-                if (utils.matchContentType(contentType, `application/octet-stream`)) {
+                if (utils.matchContentType(contentType, `application/pdf`)) {
                     res.data = httpRes?.data;
                 } else {
                     throw new errors.SDKError(


### PR DESCRIPTION
The following error is received when attempting to call invoices.downloadPdf (Xero is accounting platform):

> SDKError: unknown content-type received: application/pdf: Status 200

This is because the code is expecting content-type 'application/octet-stream', but the API endpoint returns with content-type 'application/pdf'.

Note: I attempted to log an issue but it seems that is no longer possible with the repository.